### PR TITLE
Show contact message for beta updates

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -550,6 +550,26 @@ a:hover {
   color: var(--muted);
 }
 
+.signup-form .signup-message {
+  margin: 0;
+  line-height: 1.5;
+  transition: opacity 0.2s ease;
+}
+
+.signup-form .signup-message[hidden] {
+  display: none;
+  opacity: 0;
+}
+
+.signup-form .signup-message.visible {
+  opacity: 1;
+}
+
+.signup-form .signup-message a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .site-footer {
   border-top: 1px solid var(--line);
   padding: 2.5rem 0 3rem;

--- a/index.html
+++ b/index.html
@@ -270,8 +270,17 @@
           <form class="signup-form" aria-label="Newsletter-Anmeldung">
             <label class="sr-only" for="email">E-Mail-Adresse</label>
             <!-- <input id="email" type="email" name="email" placeholder="name@mail.com" required /> -->
-            <button type="submit">2026</button>
-            <a class="hint">Der E-Mail-Verteiler wird bald freigeschaltet!</a>
+            <button type="button" aria-controls="beta-updates-message" aria-expanded="false">2026</button>
+            <p
+              id="beta-updates-message"
+              class="hint signup-message"
+              role="status"
+              aria-live="polite"
+              hidden
+            >
+              Die Mail-Liste wird bald freigeschaltet. Schreib uns gerne schon jetzt an
+              <a href="mailto:info@zeitzeugen.app">info@zeitzeugen.app</a> – wir melden uns bei dir.
+            </p>
           </form>
         </div>
       </section>
@@ -286,5 +295,22 @@
         </div>
       </div>
     </footer>
+
+    <script>
+      (function () {
+        const button = document.querySelector('.signup-form button');
+        const message = document.querySelector('.signup-form .signup-message');
+
+        if (!button || !message) return;
+
+        button.addEventListener('click', () => {
+          if (message.hidden) {
+            message.hidden = false;
+            message.classList.add('visible');
+            button.setAttribute('aria-expanded', 'true');
+          }
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- reveal a polite inline message for the 2026 update button that shares the interim contact email
- add light styling and behavior so the message appears once without reloading the page

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_b_68e52a3861e08328b41f568f6397e30d