### PR TITLE
Revamp partner landing page for Rewind

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,18 +1,18 @@
 :root {
-  --primary: #fd42b2;
-  --primary-strong: #ac2f7f;
-  --primary-soft: #ffe5f4;
-  --ink: #0f1020;
-  --ink-soft: #3d4157;
-  --muted: #6d738d;
-  --line: #e5e7f2;
-  --surface: #f8f9fd;
+  --pink: #fd42b2;
+  --plum: #4a0d59;
+  --periwinkle: #6f7edb;
+  --lilac: #d7d9f7;
+  --ink: #0f1022;
+  --ink-soft: #383c55;
+  --muted: #6b6f8b;
+  --surface: #f6f7ff;
   --white: #ffffff;
   --radius-lg: 32px;
   --radius-md: 20px;
   --radius-sm: 12px;
-  --shadow-soft: 0 30px 60px rgba(15, 16, 32, 0.08);
-  --shadow-card: 0 20px 35px rgba(15, 16, 32, 0.12);
+  --shadow-soft: 0 30px 60px rgba(15, 16, 34, 0.12);
+  --shadow-card: 0 20px 40px rgba(15, 16, 34, 0.16);
 }
 
 * {
@@ -28,23 +28,24 @@ html {
 
 body {
   margin: 0;
-  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
   color: var(--ink);
   background: var(--surface);
   -webkit-font-smoothing: antialiased;
   line-height: 1.6;
+  position: relative;
 }
 
 h1,
- h2,
- h3,
- h4,
- h5,
- h6 {
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: "Montserrat", "Inter", system-ui, sans-serif;
   font-weight: 700;
   color: var(--ink);
-  line-height: 1.15;
+  line-height: 1.1;
 }
 
 a {
@@ -52,32 +53,47 @@ a {
   text-decoration: none;
 }
 
-a:hover {
+a:hover,
+a:focus {
   text-decoration: underline;
 }
 
-.container {
-  width: min(1120px, 92vw);
-  margin: 0 auto;
+section {
+  padding: clamp(4rem, 8vw, 6rem) 0;
 }
 
 .surface {
   position: fixed;
   inset: 0;
-  z-index: -1;
-  background:
-    radial-gradient(420px 420px at 20% 15%, rgba(253, 66, 178, 0.08), transparent 65%),
-    radial-gradient(600px 420px at 80% 10%, rgba(172, 47, 127, 0.08), transparent 70%),
-    linear-gradient(180deg, var(--white), var(--surface));
+  z-index: -2;
+  background: linear-gradient(
+      120deg,
+      rgba(253, 66, 178, 0.18) 0%,
+      rgba(253, 66, 178, 0.05) 30%,
+      rgba(79, 13, 89, 0.12) 65%,
+      rgba(111, 126, 219, 0.1) 100%
+    ),
+    linear-gradient(
+      90deg,
+      rgba(253, 66, 178, 0.08) 0%,
+      rgba(74, 13, 89, 0.08) 25%,
+      rgba(111, 126, 219, 0.08) 55%,
+      rgba(215, 217, 247, 0.55) 100%
+    );
+}
+
+.container {
+  width: min(1120px, 90vw);
+  margin: 0 auto;
 }
 
 .site-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(248, 249, 253, 0.85);
-  backdrop-filter: blur(14px);
-  border-bottom: 1px solid rgba(229, 231, 242, 0.7);
+  background: rgba(246, 247, 255, 0.85);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(215, 217, 247, 0.6);
 }
 
 .header-grid {
@@ -91,7 +107,7 @@ a:hover {
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.9rem;
   font-family: "Montserrat", sans-serif;
   font-weight: 700;
   color: var(--ink);
@@ -104,15 +120,30 @@ a:hover {
   display: grid;
   place-items: center;
   font-weight: 700;
-  background: linear-gradient(135deg, var(--primary), #ac2f7f);
+  background: linear-gradient(140deg, var(--pink), var(--plum));
   color: var(--white);
-  box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 2px 8px rgba(255, 255, 255, 0.25);
+}
+
+.brand-stack {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
 }
 
 .brand-word {
-  font-size: 1rem;
-  letter-spacing: 0.04em;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+
+.brand-sub {
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
 .nav {
@@ -123,30 +154,50 @@ a:hover {
   color: var(--muted);
 }
 
-.nav a:hover,
-.nav a:focus {
-  color: var(--ink);
+.nav a {
+  font-weight: 500;
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+
+.nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(135deg, var(--pink), var(--plum));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.nav a:hover::after,
+.nav a:focus::after {
+  transform: scaleX(1);
 }
 
 .cta {
-  padding: 0.7rem 1.4rem;
+  padding: 0.75rem 1.6rem;
   border-radius: 999px;
-  background: var(--ink);
+  background: linear-gradient(135deg, var(--pink), var(--plum));
   color: var(--white);
   font-weight: 600;
   font-size: 0.95rem;
+  box-shadow: 0 12px 25px rgba(253, 66, 178, 0.3);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .cta:hover,
 .cta:focus {
   transform: translateY(-1px);
-  box-shadow: 0 10px 25px rgba(15, 16, 32, 0.15);
+  box-shadow: 0 18px 35px rgba(74, 13, 89, 0.3);
   text-decoration: none;
 }
 
 .hero {
-  padding: clamp(4rem, 10vw, 6rem) 0;
+  padding-top: clamp(6rem, 11vw, 8rem);
 }
 
 .hero-grid {
@@ -157,7 +208,7 @@ a:hover {
 }
 
 .hero-copy h1 {
-  font-size: clamp(2.8rem, 6vw, 4rem);
+  font-size: clamp(2.8rem, 5vw, 3.8rem);
   letter-spacing: -0.02em;
 }
 
@@ -165,20 +216,19 @@ a:hover {
   margin-top: 1.5rem;
   font-size: 1.1rem;
   color: var(--ink-soft);
-  max-width: 36ch;
+  max-width: 42ch;
 }
 
 .eyebrow {
   font-family: "Montserrat", sans-serif;
   text-transform: uppercase;
   font-size: 0.75rem;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.18em;
   color: var(--muted);
 }
 
 .hero-actions {
   display: flex;
-  align-items: center;
   gap: 1rem;
   margin-top: 2rem;
 }
@@ -187,516 +237,500 @@ a:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
   border-radius: 999px;
-  padding: 0.85rem 1.8rem;
+  padding: 0.85rem 1.9rem;
   font-weight: 600;
   font-size: 0.95rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .btn.primary {
-  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
+  background: linear-gradient(135deg, var(--pink), var(--plum));
   color: var(--white);
-  box-shadow: 0 16px 30px rgba(253, 66, 178, 0.25);
+  box-shadow: 0 16px 30px rgba(253, 66, 178, 0.28);
 }
 
 .btn.primary:hover,
 .btn.primary:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 22px 40px rgba(253, 66, 178, 0.3);
+  transform: translateY(-2px);
 }
 
 .btn.ghost {
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(172, 47, 127, 0.18);
-  color: var(--primary-strong);
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--ink);
+  border: 1px solid rgba(15, 16, 34, 0.08);
+  backdrop-filter: blur(8px);
 }
 
 .btn.ghost:hover,
 .btn.ghost:focus {
-  background: var(--white);
-  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.7);
 }
 
-.hero-meta {
+.hero-stats {
+  margin-top: 2.5rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin-top: clamp(2.5rem, 5vw, 3rem);
+  gap: 1.5rem;
+}
+
+.hero-stats dt {
+  font-family: "Montserrat", sans-serif;
+  font-size: 1.8rem;
+  color: var(--plum);
+}
+
+.hero-stats dd {
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
   color: var(--ink-soft);
 }
 
-.hero-meta dt {
-  font-family: "Montserrat", sans-serif;
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.hero-meta dd {
-  margin: 0;
-  font-size: 0.9rem;
-}
-
-.hero-card {
-  background: var(--white);
+.hero-panel {
+  background: rgba(255, 255, 255, 0.75);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
-  padding: 2rem;
+  padding: 2.4rem;
   display: flex;
   flex-direction: column;
-  gap: 1.8rem;
-  border: 1px solid rgba(229, 231, 242, 0.9);
+  gap: 1.6rem;
+  backdrop-filter: blur(12px);
 }
 
-.card-header,
-.card-footer {
+.panel-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
   font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
   color: var(--muted);
 }
 
-.card-header .chip {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(253, 66, 178, 0.15);
-  color: var(--primary-strong);
-  font-weight: 600;
-}
-
-.card-body .card-lead {
+.panel-title {
   font-family: "Montserrat", sans-serif;
-  font-size: 1.25rem;
-  color: var(--ink);
-  margin-bottom: 0.6rem;
+  font-size: 1.6rem;
+  margin-bottom: 0.8rem;
 }
 
-.card-body .card-sub {
-  color: var(--muted);
-  font-size: 0.95rem;
-  max-width: 36ch;
-}
-
-.card-list {
-  list-style: none;
-  display: grid;
-  gap: 0.85rem;
-}
-
-.card-list li {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: var(--radius-sm);
-  background: linear-gradient(135deg, rgba(253, 66, 178, 0.06), rgba(253, 66, 178, 0.02));
-  color: var(--ink);
-}
-
-.card-list .time {
-  font-family: "Montserrat", sans-serif;
-  font-weight: 600;
-  width: 4rem;
-}
-
-.card-list .desc {
-  font-size: 0.9rem;
+.panel-text {
   color: var(--ink-soft);
 }
 
-.card-footer .progress {
-  position: relative;
-  flex: 1;
-  height: 4px;
-  margin-right: 1rem;
-  border-radius: 999px;
-  background: rgba(172, 47, 127, 0.15);
+.panel-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
 }
 
-.card-footer .progress::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  width: 55%;
-  border-radius: inherit;
-  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
+.panel-list li {
+  display: grid;
+  grid-template-columns: 5rem 1fr;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--ink);
+}
+
+.panel-list .time {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  color: var(--plum);
+}
+
+.panel-foot {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+
+.progress {
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--pink), var(--periwinkle));
 }
 
 .section-head {
   display: grid;
-  grid-template-columns: minmax(0, 380px) minmax(0, 1fr);
-  gap: clamp(1.5rem, 5vw, 3rem);
-  align-items: center;
-  padding: clamp(3rem, 8vw, 4.5rem) 0 2rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: clamp(2rem, 6vw, 4rem);
+  align-items: end;
 }
 
 .section-head.compact {
-  grid-template-columns: minmax(0, 400px) minmax(0, 1fr);
-  padding-bottom: 1.5rem;
+  align-items: center;
 }
 
 .section-head p {
   color: var(--ink-soft);
-  font-size: 1rem;
+  font-size: 1.05rem;
 }
 
-.cards-grid {
+.intro-grid {
+  margin-top: 3rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1.8rem;
-  padding-bottom: clamp(3rem, 8vw, 4.5rem);
 }
 
-.info-card {
-  background: var(--white);
+.intro-card {
+  background: rgba(255, 255, 255, 0.75);
   border-radius: var(--radius-md);
-  padding: 2.2rem;
+  padding: 1.9rem;
   box-shadow: var(--shadow-soft);
-  border: 1px solid rgba(229, 231, 242, 0.9);
+  backdrop-filter: blur(10px);
+}
+
+.intro-card h3 {
+  font-size: 1.3rem;
+}
+
+.intro-card p {
+  margin-top: 1rem;
+  color: var(--ink-soft);
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2.5rem, 6vw, 5rem);
+  align-items: center;
+}
+
+.experience-copy p {
+  margin-top: 1.5rem;
+  color: var(--ink-soft);
+}
+
+.experience-list {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  list-style: none;
+}
+
+.experience-list li {
+  background: rgba(255, 255, 255, 0.75);
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+}
+
+.list-title {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  display: block;
+}
+
+.list-desc {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--ink-soft);
+}
+
+.experience-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.screen {
+  background: linear-gradient(135deg, rgba(253, 66, 178, 0.85), rgba(74, 13, 89, 0.85));
+  color: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+}
+
+.screen h3 {
+  font-size: 1.6rem;
+  margin-top: 0.6rem;
+}
+
+.screen p {
+  margin-top: 1rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.screen-steps {
+  margin-top: 2rem;
+  display: flex;
+  gap: 0.6rem;
+}
+
+.step {
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.step.active {
+  background: var(--white);
+  color: var(--plum);
+}
+
+.screen.footnote {
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink-soft);
+  padding: 1.2rem 1.6rem;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+}
+
+.story-grid {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.8rem;
+}
+
+.story-card {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.info-card h3 {
-  font-size: 1.2rem;
-}
-
-.info-card p {
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.moments {
-  padding: 3rem 0;
-}
-
-.moment-scroll {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(260px, 1fr);
-  gap: 1.5rem;
-  overflow-x: auto;
-  padding: 0 0 1.5rem;
-  scroll-snap-type: x mandatory;
-}
-
-.moment-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.moment-scroll::-webkit-scrollbar-thumb {
-  background: rgba(15, 16, 32, 0.2);
-  border-radius: 999px;
-}
-
-.moment {
-  background: var(--white);
-  border-radius: var(--radius-md);
-  padding: 1.8rem;
-  box-shadow: var(--shadow-soft);
-  border: 1px solid rgba(229, 231, 242, 0.9);
-  scroll-snap-align: start;
-  display: grid;
-  gap: 1.2rem;
-}
-
-.moment header {
+.story-card header {
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  align-items: center;
+  gap: 1rem;
 }
 
-.moment .tag {
+.story-card .tag {
   font-family: "Montserrat", sans-serif;
-  font-size: 0.8rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
+  font-size: 0.85rem;
   text-transform: uppercase;
-  color: var(--primary-strong);
+  letter-spacing: 0.18em;
+  color: var(--plum);
 }
 
-.moment h3 {
-  font-size: 1.3rem;
-}
-
-.moment ul {
-  list-style: none;
-  display: grid;
-  gap: 0.9rem;
-}
-
-.moment li {
-  display: grid;
-  grid-template-columns: 70px 1fr;
-  gap: 0.8rem;
-  font-size: 0.95rem;
+.story-card p {
   color: var(--ink-soft);
 }
 
-.timeline-preview {
-  padding: clamp(3rem, 8vw, 5rem) 0;
+.journey {
+  position: relative;
 }
 
-.timeline-board {
+.journey::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(111, 126, 219, 0.1), rgba(253, 66, 178, 0.1));
+  z-index: -1;
+}
+
+.journey-grid {
+  margin-top: 3.5rem;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 2rem;
-  background: var(--white);
-  border-radius: var(--radius-lg);
-  padding: clamp(2.5rem, 6vw, 3.5rem);
-  border: 1px solid rgba(229, 231, 242, 0.9);
-  box-shadow: var(--shadow-soft);
 }
 
 .lane {
   position: relative;
   padding-left: 2.5rem;
   display: grid;
-  gap: 1.5rem;
+  gap: 2rem;
 }
 
-.lane .marker {
+.lane-marker {
   position: absolute;
-  left: 1.1rem;
+  left: 1rem;
   top: 0;
   bottom: 0;
   width: 2px;
-  background: linear-gradient(180deg, rgba(253, 66, 178, 0.4), rgba(172, 47, 127, 0.15));
+  background: linear-gradient(180deg, var(--pink), var(--periwinkle));
 }
 
-.entry {
-  display: grid;
-  gap: 0.4rem;
+.lane-item {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: var(--radius-md);
+  padding: 1.6rem 1.8rem;
+  box-shadow: var(--shadow-soft);
 }
 
-.entry .time {
+.lane-step {
   font-family: "Montserrat", sans-serif;
   font-weight: 600;
-  color: var(--primary-strong);
-  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.8rem;
+  color: var(--plum);
 }
 
-.entry p {
+.lane-item p {
+  margin-top: 0.8rem;
   color: var(--ink-soft);
-  font-size: 0.95rem;
-  margin: 0;
 }
 
-.newsletter {
-  padding: clamp(4rem, 10vw, 6rem) 0 5rem;
-}
-
-.newsletter-card {
-  background: linear-gradient(135deg, rgba(253, 66, 178, 0.1), rgba(172, 47, 127, 0.05));
-  border-radius: var(--radius-lg);
-  padding: clamp(3rem, 6vw, 4rem);
+.impact-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
-  gap: clamp(2rem, 6vw, 3rem);
-  border: 1px solid rgba(253, 66, 178, 0.16);
-  box-shadow: var(--shadow-card);
-  align-items: stretch;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: clamp(2rem, 6vw, 4rem);
+  align-items: center;
 }
 
-.copy h2 {
-  font-size: clamp(2rem, 4.5vw, 2.6rem);
-}
-
-.copy p {
+.impact-grid p {
   color: var(--ink-soft);
-  max-width: 45ch;
 }
 
-.copy-secondary {
+.impact-list {
+  list-style: none;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.impact-list li {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius-md);
+  padding: 1.6rem 1.8rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.impact-number {
+  font-family: "Montserrat", sans-serif;
+  font-size: 2rem;
+  color: var(--plum);
+}
+
+.impact-text {
+  display: block;
+  margin-top: 0.6rem;
+  color: var(--ink-soft);
+}
+
+.contact {
+  padding-bottom: clamp(5rem, 10vw, 7rem);
+}
+
+.contact-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: clamp(2.5rem, 6vw, 4rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: clamp(2rem, 5vw, 3rem);
+  align-items: center;
+}
+
+.contact-copy p {
+  margin-top: 1.4rem;
+  color: var(--ink-soft);
+}
+
+.contact-note {
+  margin-top: 1.1rem;
+  font-size: 0.95rem;
   color: var(--muted);
 }
 
-/* newsletter: aside */
-.newsletter-aside {
-  position: relative;
-  padding: clamp(1.5rem, 3.5vw, 2.25rem);
+.contact-aside {
+  background: rgba(253, 66, 178, 0.12);
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.55);
-  border: 1px solid rgba(253, 66, 178, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  overflow: hidden;
-}
-
-.newsletter-aside::after {
-  content: "";
-  position: absolute;
-  inset: 20% -30% -30% 60%;
-  background: linear-gradient(135deg, rgba(253, 66, 178, 0.2), rgba(172, 47, 127, 0));
-  opacity: 0.25;
-  transform: rotate(-8deg);
+  padding: 1.8rem;
+  display: grid;
+  gap: 0.8rem;
+  justify-items: start;
 }
 
 .aside-label {
   font-family: "Montserrat", sans-serif;
-  font-size: 0.9rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--primary-strong);
-  position: relative;
-  z-index: 1;
+  letter-spacing: 0.18em;
+  font-size: 0.8rem;
+  color: var(--plum);
 }
 
 .aside-mail {
-  font-size: clamp(1.2rem, 2.8vw, 1.6rem);
-  font-weight: 600;
+  font-family: "Montserrat", sans-serif;
+  font-size: 1.1rem;
   color: var(--ink);
-  text-decoration: none;
-  position: relative;
-  z-index: 1;
-}
-
-.aside-mail:focus,
-.aside-mail:hover {
-  text-decoration: underline;
-  color: var(--primary-strong);
 }
 
 .aside-note {
-  margin: 0;
-  color: var(--ink-soft);
-  font-size: 0.95rem;
-  position: relative;
-  z-index: 1;
+  font-size: 0.9rem;
+  color: var(--muted);
 }
 
 .site-footer {
-  border-top: 1px solid var(--line);
-  padding: 2.5rem 0 3rem;
-  background: rgba(255, 255, 255, 0.75);
+  padding: 2rem 0 3rem;
+  background: rgba(246, 247, 255, 0.88);
+  border-top: 1px solid rgba(215, 217, 247, 0.7);
 }
 
 .footer-flex {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 1.5rem;
-  font-size: 0.9rem;
-  color: var(--muted);
 }
 
 .footer-links {
   display: flex;
   gap: 1.5rem;
+  font-size: 0.95rem;
 }
 
-.footer-links a:hover,
-.footer-links a:focus {
-  color: var(--primary-strong);
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-}
-
-@media (max-width: 980px) {
+@media (max-width: 960px) {
   .header-grid {
-    grid-template-columns: auto auto;
-    grid-template-areas:
-      "brand cta"
-      "nav nav";
-    row-gap: 0.8rem;
-  }
-
-  .brand {
-    grid-area: brand;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
   }
 
   .nav {
-    grid-area: nav;
-    justify-content: flex-start;
+    display: none;
   }
 
-  .cta {
-    grid-area: cta;
-    justify-self: end;
-  }
-
-  .hero-grid {
+  .hero-grid,
+  .experience-grid,
+  .impact-grid {
     grid-template-columns: 1fr;
   }
 
-  .hero-copy {
-    order: 2;
+  .hero-panel {
+    order: -1;
   }
 
-  .hero-card {
-    order: 1;
-    max-width: 440px;
-    justify-self: center;
-  }
-
-  .hero-meta {
+  .hero-stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .section-head,
-  .section-head.compact {
-    grid-template-columns: 1fr;
-    text-align: left;
-  }
-
-  .cards-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .timeline-board {
+  .section-head {
     grid-template-columns: 1fr;
   }
 
-  .newsletter-card {
+  .intro-grid,
+  .story-grid,
+  .journey-grid {
     grid-template-columns: 1fr;
   }
 
-  .newsletter-aside {
-    margin-top: 1.5rem;
+  .lane {
+    padding-left: 1.8rem;
+  }
+
+  .contact-card {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 720px) {
-  .header-grid {
-    grid-template-columns: 1fr;
-    justify-items: stretch;
-    text-align: center;
-  }
-
-  .nav {
-    justify-content: center;
-  }
-
-  .cta {
-    justify-self: center;
-    width: 100%;
-  }
-
-  .hero {
-    padding: 3.5rem 0;
-  }
-
-  .hero-copy p {
-    max-width: none;
-  }
-
-  .hero-meta {
+@media (max-width: 640px) {
+  .hero-stats {
     grid-template-columns: 1fr;
   }
 
@@ -707,35 +741,5 @@ a:hover {
 
   .btn {
     width: 100%;
-  }
-
-  .cards-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .moment-scroll {
-    grid-auto-columns: minmax(80%, 1fr);
-  }
-
-  .moment li {
-    grid-template-columns: 60px 1fr;
-  }
-
-  .footer-flex {
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .footer-links {
-    flex-direction: column;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    transition-duration: 0.001ms !important;
-    animation-duration: 0.001ms !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Zeitzeugen – wie damals, nur heute</title>
+    <title>Rewind – Partner werden</title>
     <meta
       name="description"
-      content="Zeitzeugen kündigt sich an: eine neue Art, Geschichte zu erleben – emotional, kuratiert, zeitlich spürbar. Coming Soon."
+      content="Rewind ist die kuratierte Plattform für historische Stories. Erfahre, wie du als Partner Inhalte produzierst, veröffentlichst und ein neues Publikum erreichst."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -15,12 +15,10 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="assets/css/styles.css" />
-
     <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png" />
     <link rel="icon" type="image/svg+xml" href="icons/favicon.svg" />
     <link rel="shortcut icon" href="icons/favicon.png" />
-
     <meta name="theme-color" content="#FD42B2" />
   </head>
   <body>
@@ -28,251 +26,288 @@
 
     <header class="site-header">
       <div class="container header-grid">
-        <a class="brand" href="#top" aria-label="Zeitzeugen Start">
-          <span class="brand-badge">Z</span>
-          <span class="brand-word">Zeitzeugen</span>
+        <a class="brand" href="#start" aria-label="Rewind Start">
+          <span class="brand-badge">R</span>
+          <div class="brand-stack">
+            <span class="brand-word">Rewind</span>
+            <span class="brand-sub">by Zeitzeugen</span>
+          </div>
         </a>
-        <nav aria-label="Primäre Navigation" class="nav">
-          <a href="#prinzip">Prinzip</a>
-          <a href="#momente">Momente</a>
-          <a href="#newsletter">Updates</a>
+        <nav aria-label="Hauptnavigation" class="nav">
+          <a href="#partner">Warum Rewind</a>
+          <a href="#stories">Erlebnisse</a>
+          <a href="#journey">Zusammenarbeit</a>
+          <a href="#kontakt">Kontakt</a>
         </nav>
-        <a class="cta" href="#newsletter">Updates abonnieren</a> 
+        <a class="cta" href="#kontakt">Partner anfragen</a>
       </div>
     </header>
 
-    <main>
-      <section class="hero" id="top">
+    <main id="start">
+      <section class="hero" aria-labelledby="hero-title">
         <div class="container hero-grid">
           <div class="hero-copy">
-            <span class="eyebrow">Coming Soon</span>
-            <h1>Geschichte - wie damals, nur heute.</h1>
+            <span class="eyebrow">Partnerprogramm</span>
+            <h1 id="hero-title">Rewind verwandelt historische Inhalte in erlebbare Stories.</h1>
             <p>
-              Zeitzeugen kuratiert historische Ereignisse in Echtzeit – mit Stimmen, Stimmungen und Kontext, der im Takt der
-              Geschichte entfaltet wird.
+              Wir produzieren kuratierte Audio-Erlebnisse, die Zielgruppen in Echtzeit mitnehmen. Gemeinsam mit Museen,
+              Archiven und Medienhäusern schaffen wir neue Zugänge zu Geschichte – digital, immersiv, messbar.
             </p>
             <div class="hero-actions">
-              <a class="btn primary" href="#newsletter">Werde Partner</a>
+              <a class="btn primary" href="#kontakt">Jetzt anfragen</a>
+              <a class="btn ghost" href="#partner">Mehr erfahren</a>
             </div>
-            <dl class="hero-meta" aria-label="Highlights">
+            <dl class="hero-stats" aria-label="Kennzahlen">
               <div>
-                <dt>+200</dt>
-                <dd>kuratierte Stunden Audio &amp; Quellen</dd>
+                <dt>200+</dt>
+                <dd>kuratierte Stunden aus Archiven &amp; Zeitzeugnissen</dd>
               </div>
               <div>
-                <dt>+30</dt>
-                <dd>Partner aus Kultur &amp; Forschung</dd>
+                <dt>30+</dt>
+                <dd>Partner aus Kultur, Bildung &amp; Medien</dd>
               </div>
               <div>
                 <dt>1 Ziel</dt>
-                <dd>Geschichte erleben – wie damals, nur heute</dd>
+                <dd>Geschichte fühlbar machen – für neue Publika</dd>
               </div>
             </dl>
           </div>
-          <div class="hero-card" role="presentation" aria-hidden="true">
-            <div class="card-header">
-              <span>Live-Segment</span>
-              <span class="chip">Originalton</span>
+          <aside class="hero-panel" aria-label="Rewind Erlebnis">
+            <div class="panel-head">
+              <span class="panel-kicker">Originalton</span>
+              <span class="panel-meta">Live Chronik</span>
             </div>
-            <div class="card-body">
-              <p class="card-lead">„Wir sind live in Dallas.“</p>
-              <p class="card-sub">Die Chronik beginnt 20 Minuten vor dem Attentat auf JFK und begleitet den Tag minütlich.</p>
-              <ul class="card-list">
+            <div class="panel-body">
+              <p class="panel-title">„Wir sind live in Dallas.“</p>
+              <p class="panel-text">
+                Rewind startet 20 Minuten vor dem Attentat auf JFK und führt das Publikum Szene für Szene durch den Tag.
+              </p>
+              <ul class="panel-list">
                 <li>
                   <span class="time">11:38</span>
-                  <span class="desc">Love Field · Air Force One landet</span>
+                  <span class="detail">Air Force One landet – Jubel, Radioton, Reporter:innen vor Ort.</span>
                 </li>
                 <li>
                   <span class="time">12:30</span>
-                  <span class="desc">Eilmeldung · „Es sind Schüsse gefallen!“</span>
+                  <span class="detail">„Es sind Schüsse gefallen!“ – erste Eilmeldungen, Sirenen, Chaos.</span>
                 </li>
                 <li>
                   <span class="time">13:38</span>
-                  <span class="desc">CBS bestätigt den Tod Kennedys</span>
+                  <span class="detail">CBS bestätigt Kennedys Tod. Amerika hält den Atem an.</span>
                 </li>
               </ul>
             </div>
-            <div class="card-footer">
+            <div class="panel-foot">
               <span class="progress" aria-hidden="true"></span>
-              <span class="label">Spannung baut sich auf</span>
+              <span class="progress-label">Spannung baut sich auf</span>
             </div>
-          </div>
+          </aside>
         </div>
       </section>
 
-      <section class="principles" id="prinzip">
+      <section class="intro" id="partner" aria-labelledby="intro-title">
         <div class="container section-head">
           <div>
-            <span class="eyebrow">Unser Prinzip</span>
-            <h2>Kuratiert, emotional, zeitlich.</h2>
+            <span class="eyebrow">Warum Rewind</span>
+            <h2 id="intro-title">Kuratiert wie ein Museum, dynamisch wie ein Livestream.</h2>
           </div>
           <p>
-            Zeitzeugen übersetzt historische Augenblicke in eine klare, geführte Erlebnisreise. Jede Minute ist recherchiert,
-            Quellen verifiziert, jede Szene kuratiert – für einen Zugang, der Nähe schafft statt Distanz.
+            Rewind übersetzt historische Quellen in geführte Narrative. Aus Audio, Originalmaterial und Kontext schaffen wir
+            Episoden, die Nutzer:innen in Echtzeit begleiten – mobil, im Museum oder auf Events.
           </p>
         </div>
-        <div class="container cards-grid">
-          <article class="info-card">
-            <h3>Im Rhythmus der Ereignisse</h3>
+        <div class="container intro-grid">
+          <article class="intro-card">
+            <h3>Redaktionelle Exzellenz</h3>
             <p>
-              Erlebe Geschichte genau im Tempo, in dem sie passierte. Unsere Timeline lenkt dich wie ein feiner Taktgeber durch
-              Minuten, Stimmen und Wendepunkte.
+              Unser Team recherchiert, verifiziert und kondensiert Stoffe aus Archiven. Quellen bleiben transparent – für
+              Bildung, Wissenschaft und Dokumentation.
             </p>
           </article>
-          <article class="info-card">
-            <h3>Quellen, die Vertrauen schaffen</h3>
+          <article class="intro-card">
+            <h3>Emotionale Dramaturgie</h3>
             <p>
-              Archivmaterial, Interviews, Radiosendungen. Alles strukturiert, sauber verlinkt und für die Weiterarbeit
-              dokumentiert.
+              Jede Episode folgt dem Takt der Ereignisse. Spannungsbögen, Stimmen und Klangwelten sorgen für Nähe statt
+              Distanz.
             </p>
           </article>
-          <article class="info-card">
-            <h3>Emotion trifft Kontext</h3>
+          <article class="intro-card">
+            <h3>Messbare Wirkung</h3>
             <p>
-              Jede Szene kombiniert Primärquellen mit Kommentaren und visuellen Hinweisen – für einen emotionalen Zugang ohne
-              Pathos.
+              Wir liefern Insights zu Nutzung, Interaktion und Verweildauer. So erkennst du, welche Geschichten bewegen und
+              wo Potenzial steckt.
             </p>
           </article>
         </div>
       </section>
 
-      <section class="moments" id="momente" aria-labelledby="momente-heading">
-        <div class="container">
-          <div class="section-head compact">
-            <div>
-              <span class="eyebrow">Preview</span>
-              <h2 id="momente-heading">Drei Beispiele, die du fühlen kannst.</h2>
-            </div>
-            <p>Erlebe Geschichte – oder erzähle deine eigene. Werde Partner und bringe deine Geschichten auf unsere Plattform.</p>
+      <section class="experience" aria-labelledby="experience-title">
+        <div class="container experience-grid">
+          <div class="experience-copy">
+            <span class="eyebrow">Produkt</span>
+            <h2 id="experience-title">Die Rewind Experience</h2>
+            <p>
+              Nutzer:innen erleben Ereignisse in Echtzeit – begleitet von Originaltönen, Moderation und visuellen Impulsen.
+              Kurze Kapitel halten die Aufmerksamkeit hoch und geben Raum für Kontext.
+            </p>
+            <ul class="experience-list">
+              <li>
+                <span class="list-title">Timeline-Player</span>
+                <span class="list-desc">Segmentierte Audios, Marker und Notizen machen komplexe Stoffe zugänglich.</span>
+              </li>
+              <li>
+                <span class="list-title">Story Hubs</span>
+                <span class="list-desc">Begleitende Texte, Quellen und Zitate vertiefen das Verständnis.</span>
+              </li>
+              <li>
+                <span class="list-title">Distribution</span>
+                <span class="list-desc">Einbettbar auf euren Kanälen, teilbar in Social Media und vor Ort nutzbar.</span>
+              </li>
+            </ul>
           </div>
-          <div class="moment-scroll" role="list">
-            <article class="moment" role="listitem">
-              <header>
-                <span class="tag">1963</span>
-                <h3>JFK in Dallas</h3>
-              </header>
-              <ul>
-                <li>
-                  <span class="time">11:38</span>
-                  <span class="detail">Ankunft von Air Force One – Jubel, Kameras, Radioton.</span>
-                </li>
-                <li>
-                  <span class="time">12:30</span>
-                  <span class="detail">„Es sind Schüsse gefallen!“ – erste Sirenen, Reporter:innen live.</span>
-                </li>
-                <li>
-                  <span class="time">13:38</span>
-                  <span class="detail">CBS bestätigt Kennedys Tod. Die Stadt verstummt.</span>
-                </li>
-              </ul>
-            </article>
-            <article class="moment" role="listitem">
-              <header>
-                <span class="tag">1969</span>
-                <h3>Apollo 11</h3>
-              </header>
-              <ul>
-                <li>
-                  <span class="time">09:32</span>
-                  <span class="detail">Saturn V hebt ab. Countdown, Gänsehaut, Millionen Ohren.</span>
-                </li>
-                <li>
-                  <span class="time">20:17</span>
-                  <span class="detail">„The Eagle has landed.“ – Landung im Mare Tranquillitatis.</span>
-                </li>
-                <li>
-                  <span class="time">02:56</span>
-                  <span class="detail">Erster Schritt auf dem Mond. Ein globaler Atemzug.</span>
-                </li>
-              </ul>
-            </article>
-            <article class="moment" role="listitem">
-              <header>
-                <span class="tag">1989</span>
-                <h3>Fall der Mauer</h3>
-              </header>
-              <ul>
-                <li>
-                  <span class="time">18:53</span>
-                  <span class="detail">Schabowski verkündet: „Sofort, unverzüglich.“ Verwirrung.</span>
-                </li>
-                <li>
-                  <span class="time">19:00</span>
-                  <span class="detail">Eilmeldungen, Menschen strömen zu den Grenzübergängen.</span>
-                </li>
-                <li>
-                  <span class="time">23:30</span>
-                  <span class="detail">Bornholmer Straße öffnet. Tränen, Umarmungen, Trabi-Hupen.</span>
-                </li>
-              </ul>
-            </article>
+          <div class="experience-panel" aria-hidden="true">
+            <div class="screen">
+              <span class="screen-kicker">Preview</span>
+              <h3>Apollo 11</h3>
+              <p>Countdown, Funksprüche, globale Spannung – Rewind führt in 12 Kapiteln zum ersten Schritt auf dem Mond.</p>
+              <div class="screen-steps">
+                <span class="step active">Start</span>
+                <span class="step">Mondorbit</span>
+                <span class="step">Landung</span>
+                <span class="step">Rückkehr</span>
+              </div>
+            </div>
+            <div class="screen footnote">Originalmaterial lizenziert · Kontext von Rewind kuratiert</div>
           </div>
         </div>
       </section>
 
-      <section class="timeline-preview" aria-labelledby="timeline-heading">
-        <div class="container">
-          <div class="section-head compact">
-            <div>
-              <span class="eyebrow">Partner Journey</span>
-              <h2 id="timeline-heading">Deine Geschichte verdient ein digitales Publikum.</h2>
-            </div>
-            <p>
-              Wir kuratieren, orchestrieren und messen – Gemeinsam schaffen wir Reichweite mit Substanz.  
-              Unser Team begleitet dich Schritt für Schritt – von der Idee bis zum Launch auf der Zeitzeugen-Plattform.
-            </p>
+      <section class="stories" id="stories" aria-labelledby="stories-title">
+        <div class="container section-head compact">
+          <div>
+            <span class="eyebrow">Formate</span>
+            <h2 id="stories-title">Geschichten, die wirken.</h2>
           </div>
+          <p>
+            Ob Jubiläum, Ausstellung oder Podcast-Erweiterung – Rewind öffnet historische Perspektiven und schafft neue
+            Touchpoints.
+          </p>
+        </div>
+        <div class="container story-grid" role="list">
+          <article class="story-card" role="listitem">
+            <header>
+              <span class="tag">1963</span>
+              <h3>JFK in Dallas</h3>
+            </header>
+            <p>
+              Aus Radioreports, TV-Specials und Interviews entsteht eine dichte Chronik, die jede Minute miterleben lässt.
+            </p>
+          </article>
+          <article class="story-card" role="listitem">
+            <header>
+              <span class="tag">1969</span>
+              <h3>Apollo 11</h3>
+            </header>
+            <p>
+              Von der Saturn-V-Zündung bis zur Mondlandung. Rewind verdichtet die Mission zu einer immersiven Experience.
+            </p>
+          </article>
+          <article class="story-card" role="listitem">
+            <header>
+              <span class="tag">1989</span>
+              <h3>Fall der Mauer</h3>
+            </header>
+            <p>
+              Augenzeug:innen, Archivmaterial und Live-Schalten zeigen die Stunden, die Europa verändert haben.
+            </p>
+          </article>
+        </div>
+      </section>
 
-          <div class="timeline-board" role="presentation" aria-hidden="true">
-            <div class="lane">
-              <span class="marker"></span>
-              <div class="entry">
-                <span class="time">1. Kick-off & Zielbild</span>
-                <p>Inhalte, Zielgruppen und Wirkung klären. Scope, Rollen, Timing stehen – schnell und schlank.</p>
-              </div>
-              <div class="entry">
-                <span class="time">2. Storyboard & Taktung</span>
-                <p>Wir übersetzen deine Geschichte in den Zeitzeugen-Flow: Momente, Trigger, Originaltöne.</p>
-              </div>
-              <div class="entry">
-                <span class="time">3. Build & Playtest</span>
-                <p>Unsere Experience-Engine orchestriert Audio, Text, Visuals. Iterationen mit eurem Team.</p>
-              </div>
+      <section class="journey" id="journey" aria-labelledby="journey-title">
+        <div class="container section-head">
+          <div>
+            <span class="eyebrow">Zusammenarbeit</span>
+            <h2 id="journey-title">So arbeiten wir mit Partnern.</h2>
+          </div>
+          <p>
+            Von der Idee bis zur Premiere begleiten wir euch eng. Prozesse bleiben schlank, Kommunikation transparent.
+          </p>
+        </div>
+        <div class="container journey-grid" role="presentation">
+          <div class="lane">
+            <div class="lane-marker"></div>
+            <div class="lane-item">
+              <span class="lane-step">Kick-off</span>
+              <p>Gemeinsame Zieldefinition, Auswahl der Quellen und Audience Mapping.</p>
             </div>
-
-            <div class="lane">
-              <span class="marker"></span>
-              <div class="entry">
-                <span class="time">4. Premiere</span>
-                <p>Live auf Zeitzeugen: kuratiert, teilbar, im echten Zeitzeugen-Takt – Bühne frei für eure Geschichte!</p>
-              </div>
-              <div class="entry">
-                <span class="time">5. Insights & Statistiken</span>
-                <p>Feedback, Likes/Dislikes und Nutzungsdaten zeigen, was berührt. Wir schärfen Inhalte und Distribution.</p>
-              </div>
-              <div class="entry">
-                <span class="time">6. Nächste Geschichte</span>
-                <p>Auf Basis der Insights planen wir das nächste Kapitel – schneller, fokussierter, wirkungsvoller.</p>
-              </div>
+            <div class="lane-item">
+              <span class="lane-step">Storyboard</span>
+              <p>Wir kuratieren Timeline, Dramaturgie und Sprecher:innen – abgestimmt auf eure Ziele.</p>
+            </div>
+            <div class="lane-item">
+              <span class="lane-step">Production</span>
+              <p>Audio-Produktion, Sounddesign, Visuals. Iterationen im engen Austausch mit eurem Team.</p>
+            </div>
+          </div>
+          <div class="lane">
+            <div class="lane-marker"></div>
+            <div class="lane-item">
+              <span class="lane-step">Launch</span>
+              <p>Veröffentlichung auf Rewind – integriert in eure Kommunikationskanäle.</p>
+            </div>
+            <div class="lane-item">
+              <span class="lane-step">Insights</span>
+              <p>Wir liefern Daten zu Nutzung, Feedback und Engagement für Reporting und Optimierung.</p>
+            </div>
+            <div class="lane-item">
+              <span class="lane-step">Next Chapter</span>
+              <p>Gemeinsam planen wir Folgeformate oder Serien, basierend auf den Insights.</p>
             </div>
           </div>
         </div>
       </section>
 
-
-      <section class="newsletter" id="newsletter" role="region" aria-labelledby="newsletter-title">
-        <div class="container newsletter-card">
-          <div class="copy">
-            <span class="eyebrow">Für Partner</span>
-            <h2 id="newsletter-title">Deine Geschichte. Unsere Plattform.</h2>
-            <p>Die Beta startet bald – als Partner kannst du dich schon jetzt melden.</p>
+      <section class="impact" aria-labelledby="impact-title">
+        <div class="container impact-grid">
+          <div>
+            <span class="eyebrow">Impact</span>
+            <h2 id="impact-title">Warum Partner mit Rewind wachsen.</h2>
             <p>
-              Schreib uns an – wir antworten persönlich.
+              Rewind verbindet journalistische Sorgfalt mit einer Experience, die Menschen bindet. Ausstellungen, Podcasts,
+              Festivals oder Bildungsangebote werden verlängert und begleitet.
             </p>
-            <p class="copy-secondary">Nur informiert bleiben? Wir geben Bescheid, sobald die Beta-Liste öffnet.</p>
           </div>
-          <div class="newsletter-aside" aria-labelledby="newsletter-contact">
-            <span class="aside-label" id="newsletter-contact">Partner-Kontakt</span>
+          <ul class="impact-list">
+            <li>
+              <span class="impact-number">72%</span>
+              <span class="impact-text">durchschnittliche Completion Rate über alle Episoden hinweg.</span>
+            </li>
+            <li>
+              <span class="impact-number">15 min</span>
+              <span class="impact-text">durchschnittliche Verweildauer pro Session auf Rewind Experiences.</span>
+            </li>
+            <li>
+              <span class="impact-number">+48%</span>
+              <span class="impact-text">Interaktion mit weiterführenden Quellen nach Abschluss einer Episode.</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="contact" id="kontakt" aria-labelledby="contact-title">
+        <div class="container contact-card">
+          <div class="contact-copy">
+            <span class="eyebrow">Kontakt</span>
+            <h2 id="contact-title">Lass uns deine Geschichte erzählen.</h2>
+            <p>
+              Du möchtest ein historisches Ereignis modern erlebbar machen oder bestehende Inhalte neu kuratieren? Wir freuen
+              uns über eine kurze Nachricht.
+            </p>
+            <p class="contact-note">Wir melden uns persönlich und vereinbaren einen Termin für ein Kennenlernen.</p>
+          </div>
+          <div class="contact-aside" aria-labelledby="contact-label">
+            <span class="aside-label" id="contact-label">Partner-Kontakt</span>
             <a class="aside-mail" href="mailto:partner@zeitzeugen.app">partner@zeitzeugen.app</a>
             <p class="aside-note">Kurzer Ping genügt.</p>
           </div>
@@ -282,13 +317,18 @@
 
     <footer class="site-footer">
       <div class="container footer-flex">
-        <small>© Zeitzeugen App</small>
+        <small>© <span id="year">2024</span> Zeitzeugen</small>
         <div class="footer-links">
           <a href="mailto:info@zeitzeugen.app">info@zeitzeugen.app</a>
-          <a href="#top">Nach oben</a>
+          <a href="#start">Nach oben</a>
         </div>
       </div>
     </footer>
-
+    <script>
+      const yearEl = document.getElementById('year');
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear().toString();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the landing page to introduce the Rewind partner program with refreshed content and sections for value, product, stories, journey, impact, and contact
- restyle the site with a clean palette inspired by the presentation slides and new layout components for cards, panels, and timelines
- add a small inline script to keep the footer year current

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f05fbb3cc8328a115dffce4d4100f)